### PR TITLE
ci: added workflow for release and updating readme on release

### DIFF
--- a/.github/workflows/publish-modules.yml
+++ b/.github/workflows/publish-modules.yml
@@ -1,0 +1,35 @@
+name: publish hcl modules
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Bump version and release
+        id: create_tag
+        uses: rymndhng/release-on-push-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          bump_version_scheme: patch
+
+      - name: Get HCL files to release
+        id: find_files
+        run: |
+          files=`find aws -name "*hcl"|awk '{a=$0; gsub("modules/", "", $0); gsub("/", "_", $0); print $0":"a}'|xargs`
+          echo "::set-output name=hcl_files::$files"
+        
+      - name: Upload assets
+        uses: meeDamian/github-release@2.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ steps.create_tag.outputs.tag_name }}
+          allow_override: true
+          gzip: false
+          files: >
+            ${{ steps.find_files.outputs.hcl_files }}

--- a/.github/workflows/publish-modules.yml
+++ b/.github/workflows/publish-modules.yml
@@ -1,4 +1,4 @@
-name: publish hcl modules
+name: publish openmetrics-exporter modules
 on:
   push:
     branches: [ master ]

--- a/.github/workflows/scripts/footer.txt
+++ b/.github/workflows/scripts/footer.txt
@@ -1,0 +1,3 @@
+You can download modules for previous releases [here](https://github.com/last9/openmetrics-registy/releases). 
+
+## Learn more about openmetrics-exporter

--- a/.github/workflows/scripts/header.txt
+++ b/.github/workflows/scripts/header.txt
@@ -1,0 +1,5 @@
+# Openmetrics-exporter registry
+
+openmetrics-exporter registry contains openmetrics-exporter modules for AWS components like, RDS, ALB etc. 
+
+## Modules and downloads

--- a/.github/workflows/scripts/update-readme.sh
+++ b/.github/workflows/scripts/update-readme.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# This script prepares the charts.yaml files for data-services and platform-services of hypertrace based on the latest version of those services.
+
+print_header() {
+    cat ".github/workflows/scripts/header.txt"
+    echo
+}
+
+print_footer() {
+    cat ".github/workflows/scripts/footer.txt"
+    echo
+}
+
+update_readme () {
+        print_header
+        echo ''
+        echo '| Module Name | Latest Version | Download |'
+        echo '| ------- | -------- | --------- | '
+        echo '| AWS Cloudwatch ALB | '$module_version '| [Download](https://github.com/last9/openmetrics-registy/releases/download/'$module_version'/aws_cloudwatch_alb.hcl) | '
+        echo '| AWS Cloudwatch API Gateway | '$module_version '| [Download](https://github.com/last9/openmetrics-registy/releases/download/'$module_version'/aws_cloudwatch_apigateway.hcl) | '
+        echo '| AWS Cloudwatch EC2 | '$module_version '| [Download](https://github.com/last9/openmetrics-registy/releases/download/'$module_version'/aws_cloudwatch_ec2.hcl) | '
+        echo '| AWS Cloudwatch EKS | '$module_version '| [Download](https://github.com/last9/openmetrics-registy/releases/download/'$module_version'/aws_cloudwatch_eks.hcl) | '
+        echo '| AWS Cloudwatch ELB | '$module_version '| [Download](https://github.com/last9/openmetrics-registy/releases/download/'$module_version'/aws_cloudwatch_elb.hcl) | '
+        echo '| AWS Cloudwatch Lambda | '$module_version '| [Download](https://github.com/last9/openmetrics-registy/releases/download/'$module_version'/aws_cloudwatch_lambda.hcl) | '
+        echo '| AWS Cloudwatch NLB | '$module_version '| [Download](https://github.com/last9/openmetrics-registy/releases/download/'$module_version'/aws_cloudwatch_nlb.hcl) | '
+        echo '| AWS Cloudwatch RDS | '$module_version '| [Download](https://github.com/last9/openmetrics-registy/releases/download/'$module_version'/aws_cloudwatch_rds.hcl) | '
+        echo ''
+        print_footer
+}
+
+if [ $1 == "update-readme" ]; then
+    readme_file="README.md"
+    update_readme > "${readme_file}"
+fi

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -1,0 +1,49 @@
+name: update-readme on release
+on: 
+  release:
+    types:
+      - created
+
+jobs:
+  get-latest-releases:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with: 
+          ref: main
+      - name: Get latest version of openmetrics-registry
+        id: openmetrics-registry
+        uses: oprypin/find-latest-tag@v1
+        with:
+          repository: ${{ github.repository }}
+
+      - name: Update readme
+        run: |
+          chmod +x .github/workflows/scripts/update-readme.sh
+          ./.github/workflows/scripts/update-readme.sh update-readme
+        env: 
+          module_version: ${{ steps.openmetrics-registry.outputs.tag }}
+
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: updated readme
+          committer: GitHub <noreply@github.com>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          signoff: false
+          branch: updated-readme-on-release
+          delete-branch: true
+          title: 'chore: updates version and donwload links of modules in readme'
+          body: |
+            This PR,
+            - Updates versions and download links of openmetrics-exporter modules in README. 
+            - **Note: This is auto-generated PR so please test and verify before merging.** 
+          labels: |
+            readme-updates
+            automated pr
+            release
+          assignees: JBAhire
+          draft: false
+      


### PR DESCRIPTION
### Description
- This PR adds workflow to release modules whenever we merge PR in the master branch. 
- All modules are stored in GitHub release assets. 
- Update-readme workflow updates the latest available version of modules and module download link as per the latest release version. 
- Update-readme workflow runs on every release and creates a PR to update README. We can also configure it to merge automatically. 

### Testing
I have tried to configure the release and tested readme generation on my personal test repository. Screenshot here for reference: 
<img width="1312" alt="Screenshot 2022-02-16 at 10 34 22 PM" src="https://user-images.githubusercontent.com/26570044/154318886-5a6a5478-3b62-4b5d-9651-f97cf5963e89.png">

### Documentation impact
- Update the link for _[how do I find right modules?](https://last9.notion.site/Writing-openmetrics-exporter-files-611155215546409a989236ded1a90a8f)_ once this is merged. 

### Should be checked before merge
**_Workflow uses `GITHUB_TOKEN` environment variable, which we need to add to the repository before we merge this so it will work._** 
