### PR TITLE
Chore: Uploads docker-compose, k8s manifests in release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: test
         run: echo ${{ steps.find_files.outputs.hcl_files }}
 
-      - name: Upload assets
+      - name: Upload release assets
         uses: meeDamian/github-release@2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -43,3 +43,7 @@ jobs:
           gzip: false
           files: >
             ${{ steps.find_files.outputs.hcl_files }}
+            docker-compose.yaml:sample/docker-compose.yaml
+            generate_ome_data.sh:sample/k8s/generate_ome_data.sh
+            ome.yaml:sample/k8s/ome.yaml
+            ome-prometheus.yaml:sample/k8s/ome-prometheus.yaml


### PR DESCRIPTION
The release workflow now also uploads the helper scripts that will be
used for running openmetrics-exporter on k8s/docker-compose