### PR TITLE
chore: converts latency to be a vector as it should be.

### DIFF
--- a/aws/cloudwatch/alb/alb.hcl
+++ b/aws/cloudwatch/alb/alb.hcl
@@ -20,11 +20,11 @@ scraper aws_alb_cloudwatch module {
   }
 
   vector "latency" {
-    dimension_label = "latency"
+    dimension_label = "stat"
 
-    source cloudwatch "p50" {
+    source cloudwatch "min" {
       query {
-        aggregator  = "p50"
+        aggregator  = "Minimum"
         namespace   = "AWS/ApplicationELB"
         metric_name = "TargetResponseTime"
 
@@ -34,45 +34,21 @@ scraper aws_alb_cloudwatch module {
       }
     }
 
-    source cloudwatch "p75" {
-      query {
-        aggregator  = "p75"
-        namespace   = "AWS/ApplicationELB"
-        metric_name = "TargetResponseTime"
-
-        dimensions = {
-          LoadBalancer = resources.each.LoadBalancer
-        }
-      }
-    }
-
-    source cloudwatch "p90" {
-      query {
-        aggregator  = "p90"
-        namespace   = "AWS/ApplicationELB"
-        metric_name = "TargetResponseTime"
-
-        dimensions = {
-          LoadBalancer = resources.each.LoadBalancer
-        }
-      }
-    }
-
-    source cloudwatch "p99" {
-      query {
-        aggregator  = "p99"
-        namespace   = "AWS/ApplicationELB"
-        metric_name = "TargetResponseTime"
-
-        dimensions = {
-          LoadBalancer = resources.each.LoadBalancer
-        }
-      }
-    }
-
-    source cloudwatch "p100" {
+    source cloudwatch "max" {
       query {
         aggregator  = "Maximum"
+        namespace   = "AWS/ApplicationELB"
+        metric_name = "TargetResponseTime"
+
+        dimensions = {
+          LoadBalancer = resources.each.LoadBalancer
+        }
+      }
+    }
+
+    source cloudwatch "avg" {
+      query {
+        aggregator  = "Average"
         namespace   = "AWS/ApplicationELB"
         metric_name = "TargetResponseTime"
 
@@ -292,11 +268,11 @@ scraper aws_alb_target_group_cloudwatch module {
 
 
   vector "latency" {
-    dimension_label = "latency"
+    dimension_label = "stat"
 
-    source cloudwatch "p50" {
+    source cloudwatch "min" {
       query {
-        aggregator  = "p50"
+        aggregator  = "Minimum"
         namespace   = "AWS/ApplicationELB"
         metric_name = "TargetResponseTime"
 
@@ -307,46 +283,7 @@ scraper aws_alb_target_group_cloudwatch module {
       }
     }
 
-    source cloudwatch "p75" {
-      query {
-        aggregator  = "p75"
-        namespace   = "AWS/ApplicationELB"
-        metric_name = "TargetResponseTime"
-
-        dimensions = {
-          LoadBalancer = resources.each.LoadBalancer
-          TargetGroup  = resources.each.TargetGroup
-        }
-      }
-    }
-
-    source cloudwatch "p90" {
-      query {
-        aggregator  = "p90"
-        namespace   = "AWS/ApplicationELB"
-        metric_name = "TargetResponseTime"
-
-        dimensions = {
-          LoadBalancer = resources.each.LoadBalancer
-          TargetGroup  = resources.each.TargetGroup
-        }
-      }
-    }
-
-    source cloudwatch "p99" {
-      query {
-        aggregator  = "p99"
-        namespace   = "AWS/ApplicationELB"
-        metric_name = "TargetResponseTime"
-
-        dimensions = {
-          LoadBalancer = resources.each.LoadBalancer
-          TargetGroup  = resources.each.TargetGroup
-        }
-      }
-    }
-
-    source cloudwatch "p100" {
+    source cloudwatch "max" {
       query {
         aggregator  = "Maximum"
         namespace   = "AWS/ApplicationELB"
@@ -358,6 +295,18 @@ scraper aws_alb_target_group_cloudwatch module {
         }
       }
     }
-  }
 
+    source cloudwatch "avg" {
+      query {
+        aggregator  = "Average"
+        namespace   = "AWS/ApplicationELB"
+        metric_name = "TargetResponseTime"
+
+        dimensions = {
+          LoadBalancer = resources.each.LoadBalancer
+          TargetGroup  = resources.each.TargetGroup
+        }
+      }
+    }
+  }
 }

--- a/aws/cloudwatch/apigateway/apigateway.hcl
+++ b/aws/cloudwatch/apigateway/apigateway.hcl
@@ -21,11 +21,11 @@ scraper aws_apigateway_cloudwatch module {
   }
 
   vector latency {
-    dimension_label = "latency"
+    dimension_label = "stat"
 
-    source cloudwatch "p50" {
+    source cloudwatch "min" {
       query {
-        aggregator  = "p50"
+        aggregator  = "Minimum"
         namespace   = "AWS/ApiGateway"
         metric_name = "Latency"
 
@@ -35,22 +35,9 @@ scraper aws_apigateway_cloudwatch module {
         }
       }
     }
-    source cloudwatch "p75" {
+    source cloudwatch "max" {
       query {
-        aggregator  = "p75"
-        namespace   = "AWS/ApiGateway"
-        metric_name = "Latency"
-
-        dimensions = {
-          ApiName = resources.each.ApiName
-          Stage   = resources.each.Stage
-        }
-      }
-    }
-
-    source cloudwatch "p90" {
-      query {
-        aggregator  = "p90"
+        aggregator  = "Maximum"
         namespace   = "AWS/ApiGateway"
         metric_name = "Latency"
 
@@ -61,22 +48,9 @@ scraper aws_apigateway_cloudwatch module {
       }
     }
 
-    source cloudwatch "p99" {
+    source cloudwatch "avg" {
       query {
-        aggregator  = "p99"
-        namespace   = "AWS/ApiGateway"
-        metric_name = "Latency"
-
-        dimensions = {
-          ApiName = resources.each.ApiName
-          Stage   = resources.each.Stage
-        }
-      }
-    }
-
-    source cloudwatch "p100" {
-      query {
-        aggregator  = "p100"
+        aggregator  = "Average"
         namespace   = "AWS/ApiGateway"
         metric_name = "Latency"
 

--- a/aws/cloudwatch/elasticcache/elasticcache.hcl
+++ b/aws/cloudwatch/elasticcache/elasticcache.hcl
@@ -111,26 +111,12 @@ scraper aws_elasticache_redis_cloudwatch module {
     }
   }
 
-  latency "latency_histo" {
-    error_margin = 0.05
-    multiplier   = 0.001
+  vector "latency" {
+    dimension_label = "stat"
 
-    source cloudwatch "throughput" {
+    source cloudwatch "min" {
       query {
-        aggregator  = "Sum"
-        namespace   = "AWS/ElastiCache"
-        metric_name = "SetTypeCmds"
-
-        dimensions = {
-          CacheClusterId = resources.each.CacheClusterId
-          CacheNodeId    = "0001"
-        }
-      }
-    }
-
-    source cloudwatch "p50" {
-      query {
-        aggregator  = "p50"
+        aggregator  = "Minimum"
         namespace   = "AWS/ElastiCache"
         metric_name = "SetTypeCmdsLatency"
 
@@ -141,9 +127,9 @@ scraper aws_elasticache_redis_cloudwatch module {
       }
     }
 
-    source cloudwatch "p75" {
+    source cloudwatch "max" {
       query {
-        aggregator  = "p75"
+        aggregator  = "Maximum"
         namespace   = "AWS/ElastiCache"
         metric_name = "SetTypeCmdsLatency"
 
@@ -154,22 +140,9 @@ scraper aws_elasticache_redis_cloudwatch module {
       }
     }
 
-    source cloudwatch "p90" {
+    source cloudwatch "avg" {
       query {
-        aggregator  = "p90"
-        namespace   = "AWS/ElastiCache"
-        metric_name = "SetTypeCmdsLatency"
-
-        dimensions = {
-          CacheClusterId = resources.each.CacheClusterId
-          CacheNodeId    = "0001"
-        }
-      }
-    }
-
-    source cloudwatch "p99" {
-      query {
-        aggregator  = "p99"
+        aggregator  = "Average"
         namespace   = "AWS/ElastiCache"
         metric_name = "SetTypeCmdsLatency"
 

--- a/aws/cloudwatch/elb/elb.hcl
+++ b/aws/cloudwatch/elb/elb.hcl
@@ -91,11 +91,11 @@ scraper aws_elb_cloudwatch module {
   }
 
   vector "latency" {
-    dimension_label = "latency"
+    dimension_label = "stat"
 
-    source cloudwatch "p50" {
+    source cloudwatch "min" {
       query {
-        aggregator  = "p50"
+        aggregator  = "Minimum"
         namespace   = "AWS/ELB"
         metric_name = "Latency"
 
@@ -105,45 +105,21 @@ scraper aws_elb_cloudwatch module {
       }
     }
 
-    source cloudwatch "p75" {
-      query {
-        aggregator  = "p75"
-        namespace   = "AWS/ELB"
-        metric_name = "Latency"
-
-        dimensions = {
-          LoadBalancerName = resources.each.LoadBalancerName
-        }
-      }
-    }
-
-    source cloudwatch "p90" {
-      query {
-        aggregator  = "p90"
-        namespace   = "AWS/ELB"
-        metric_name = "Latency"
-
-        dimensions = {
-          LoadBalancerName = resources.each.LoadBalancerName
-        }
-      }
-    }
-
-    source cloudwatch "p99" {
-      query {
-        aggregator  = "p99"
-        namespace   = "AWS/ELB"
-        metric_name = "Latency"
-
-        dimensions = {
-          LoadBalancerName = resources.each.LoadBalancerName
-        }
-      }
-    }
-
-    source cloudwatch "p100" {
+    source cloudwatch "max" {
       query {
         aggregator  = "Maximum"
+        namespace   = "AWS/ELB"
+        metric_name = "Latency"
+
+        dimensions = {
+          LoadBalancerName = resources.each.LoadBalancerName
+        }
+      }
+    }
+
+    source cloudwatch "avg" {
+      query {
+        aggregator  = "Average"
         namespace   = "AWS/ELB"
         metric_name = "Latency"
 

--- a/aws/cloudwatch/lambda/lambda.hcl
+++ b/aws/cloudwatch/lambda/lambda.hcl
@@ -19,22 +19,12 @@ scraper aws_lambda_cloudwatch module {
     }
   }
 
-  latency "latency_histo" {
-    source cloudwatch "throughput" {
-      query {
-        aggregator  = "Sum"
-        namespace   = "AWS/Lambda"
-        metric_name = "Invocations"
+  vector "latency" {
+    dimension_label = "stat"
 
-        dimensions = {
-          FunctionName = resources.each.FunctionName
-        }
-      }
-    }
-
-    source cloudwatch "p50" {
+    source cloudwatch "min" {
       query {
-        aggregator  = "p50"
+        aggregator  = "Minimum"
         namespace   = "AWS/Lambda"
         metric_name = "Duration"
 
@@ -44,9 +34,9 @@ scraper aws_lambda_cloudwatch module {
       }
     }
 
-    source cloudwatch "p75" {
+    source cloudwatch "max" {
       query {
-        aggregator  = "p75"
+        aggregator  = "Maximum"
         namespace   = "AWS/Lambda"
         metric_name = "Duration"
 
@@ -56,33 +46,9 @@ scraper aws_lambda_cloudwatch module {
       }
     }
 
-    source cloudwatch "p90" {
+    source cloudwatch "avg" {
       query {
-        aggregator  = "p90"
-        namespace   = "AWS/Lambda"
-        metric_name = "Duration"
-
-        dimensions = {
-          FunctionName = resources.each.FunctionName
-        }
-      }
-    }
-
-    source cloudwatch "p99" {
-      query {
-        aggregator  = "p99"
-        namespace   = "AWS/Lambda"
-        metric_name = "Duration"
-
-        dimensions = {
-          FunctionName = resources.each.FunctionName
-        }
-      }
-    }
-
-    source cloudwatch "p100" {
-      query {
-        aggregator  = "p100"
+        aggregator  = "Average"
         namespace   = "AWS/Lambda"
         metric_name = "Duration"
 


### PR DESCRIPTION
This PR, 
- Converts latency metrics to vector instead of latency as a type. 
