### PR TITLE
Fix stats across modules

### DIFF
--- a/aws/cloudwatch/alb/alb.hcl
+++ b/aws/cloudwatch/alb/alb.hcl
@@ -22,9 +22,9 @@ scraper aws_alb_cloudwatch module {
   vector "latency" {
     dimension_label = "stat"
 
-    source cloudwatch "min" {
+    source cloudwatch "count" {
       query {
-        aggregator  = "Minimum"
+        aggregator  = "SampleCount"
         namespace   = "AWS/ApplicationELB"
         metric_name = "TargetResponseTime"
 
@@ -34,21 +34,9 @@ scraper aws_alb_cloudwatch module {
       }
     }
 
-    source cloudwatch "max" {
+    source cloudwatch "sum" {
       query {
-        aggregator  = "Maximum"
-        namespace   = "AWS/ApplicationELB"
-        metric_name = "TargetResponseTime"
-
-        dimensions = {
-          LoadBalancer = resources.each.LoadBalancer
-        }
-      }
-    }
-
-    source cloudwatch "avg" {
-      query {
-        aggregator  = "Average"
+        aggregator  = "Sum"
         namespace   = "AWS/ApplicationELB"
         metric_name = "TargetResponseTime"
 
@@ -58,7 +46,6 @@ scraper aws_alb_cloudwatch module {
       }
     }
   }
-
 
   vector "response" {
     // Ideally we should record all individual status codes in this vector,
@@ -313,9 +300,9 @@ scraper aws_alb_target_group_cloudwatch module {
   vector "latency" {
     dimension_label = "stat"
 
-    source cloudwatch "min" {
+    source cloudwatch "count" {
       query {
-        aggregator  = "Minimum"
+        aggregator  = "SampleCount"
         namespace   = "AWS/ApplicationELB"
         metric_name = "TargetResponseTime"
 
@@ -326,22 +313,9 @@ scraper aws_alb_target_group_cloudwatch module {
       }
     }
 
-    source cloudwatch "max" {
+    source cloudwatch "sum" {
       query {
-        aggregator  = "Maximum"
-        namespace   = "AWS/ApplicationELB"
-        metric_name = "TargetResponseTime"
-
-        dimensions = {
-          LoadBalancer = resources.each.LoadBalancer
-          TargetGroup  = resources.each.TargetGroup
-        }
-      }
-    }
-
-    source cloudwatch "avg" {
-      query {
-        aggregator  = "Average"
+        aggregator  = "Sum"
         namespace   = "AWS/ApplicationELB"
         metric_name = "TargetResponseTime"
 

--- a/aws/cloudwatch/apigateway/apigateway.hcl
+++ b/aws/cloudwatch/apigateway/apigateway.hcl
@@ -53,7 +53,7 @@ scraper aws_apigateway_cloudwatch module {
   gauge "integration_latency" {
     source cloudwatch "integration_latency" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "AWS/ApiGateway"
         metric_name = "IntegrationLatency"
 

--- a/aws/cloudwatch/apigateway/apigateway.hcl
+++ b/aws/cloudwatch/apigateway/apigateway.hcl
@@ -20,24 +20,12 @@ scraper aws_apigateway_cloudwatch module {
     }
   }
 
-  vector latency {
+  vector "latency" {
     dimension_label = "stat"
 
-    source cloudwatch "min" {
+    source cloudwatch "count" {
       query {
-        aggregator  = "Minimum"
-        namespace   = "AWS/ApiGateway"
-        metric_name = "Latency"
-
-        dimensions = {
-          ApiName = resources.each.ApiName
-          Stage   = resources.each.Stage
-        }
-      }
-    }
-    source cloudwatch "max" {
-      query {
-        aggregator  = "Maximum"
+        aggregator  = "SampleCount"
         namespace   = "AWS/ApiGateway"
         metric_name = "Latency"
 
@@ -48,9 +36,9 @@ scraper aws_apigateway_cloudwatch module {
       }
     }
 
-    source cloudwatch "avg" {
+    source cloudwatch "sum" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Sum"
         namespace   = "AWS/ApiGateway"
         metric_name = "Latency"
 

--- a/aws/cloudwatch/aurora/aurora.hcl
+++ b/aws/cloudwatch/aurora/aurora.hcl
@@ -23,7 +23,7 @@ scraper aws_aurora_instance_logical_cloudwatch module {
   gauge "read_throughput" {
     source cloudwatch "read_throughput" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Sum"
         namespace   = "AWS/RDS"
         metric_name = "ReadThroughput"
 
@@ -38,7 +38,7 @@ scraper aws_aurora_instance_logical_cloudwatch module {
   gauge "read_latency" {
     source cloudwatch "read_latency" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "AWS/RDS"
         metric_name = "ReadLatency"
 
@@ -52,7 +52,7 @@ scraper aws_aurora_instance_logical_cloudwatch module {
   gauge "write_throughput" {
     source cloudwatch "write_throughput" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Sum"
         namespace   = "AWS/RDS"
         metric_name = "WriteThroughput"
 
@@ -66,7 +66,7 @@ scraper aws_aurora_instance_logical_cloudwatch module {
   gauge "write_latency" {
     source cloudwatch "write_latency" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "AWS/RDS"
         metric_name = "WriteLatency"
 
@@ -80,7 +80,7 @@ scraper aws_aurora_instance_logical_cloudwatch module {
   gauge "update_throughput" {
     source cloudwatch "update_throughput" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Sum"
         namespace   = "AWS/RDS"
         metric_name = "UpdateThroughput"
 
@@ -94,7 +94,7 @@ scraper aws_aurora_instance_logical_cloudwatch module {
   gauge "update_latency" {
     source cloudwatch "update_latency" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "AWS/RDS"
         metric_name = "UpdateLatency"
 
@@ -108,7 +108,7 @@ scraper aws_aurora_instance_logical_cloudwatch module {
   gauge "delete_throughput" {
     source cloudwatch "delete_throughput" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Sum"
         namespace   = "AWS/RDS"
         metric_name = "DeleteThroughput"
 
@@ -122,7 +122,7 @@ scraper aws_aurora_instance_logical_cloudwatch module {
   gauge "delete_latency" {
     source cloudwatch "delete_latency" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "AWS/RDS"
         metric_name = "DeleteLatency"
 
@@ -159,7 +159,7 @@ scraper aws_aurora_instance_physical_cloudwatch module {
   gauge "network_in" {
     source cloudwatch "network_in" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Sum"
         namespace   = "AWS/RDS"
         metric_name = "NetworkReceiveThroughput"
 
@@ -173,7 +173,7 @@ scraper aws_aurora_instance_physical_cloudwatch module {
   gauge "network_out" {
     source cloudwatch "network_out" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Sum"
         namespace   = "AWS/RDS"
         metric_name = "NetworkTransmitThroughput"
 
@@ -187,7 +187,7 @@ scraper aws_aurora_instance_physical_cloudwatch module {
   gauge "cpu" {
     source cloudwatch "cpu" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "AWS/RDS"
         metric_name = "CPUUtilization"
 

--- a/aws/cloudwatch/cloudfront/cloudfront.hcl
+++ b/aws/cloudwatch/cloudfront/cloudfront.hcl
@@ -9,7 +9,7 @@ scraper aws_cloudfront_cloudwatch module {
   gauge "status_5xx" {
     source cloudwatch "5xx" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "AWS/CloudFront"
         metric_name = "5xxErrorRate"
         dimensions = {
@@ -23,7 +23,7 @@ scraper aws_cloudfront_cloudwatch module {
   gauge "status_4xx" {
     source cloudwatch "4xx" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "AWS/CloudFront"
         metric_name = "4xxErrorRate"
         dimensions = {

--- a/aws/cloudwatch/dax/dax.hcl
+++ b/aws/cloudwatch/dax/dax.hcl
@@ -84,7 +84,7 @@ scraper aws_dax_cloudwatch module {
   gauge "cache_memory" {
     source cloudwatch "memory" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "AWS/DAX"
         metric_name = "CacheMemoryUtilization"
 
@@ -99,7 +99,7 @@ scraper aws_dax_cloudwatch module {
   gauge "cpu" {
     source cloudwatch "cpu" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "AWS/DAX"
         metric_name = "CPUUtilization"
 

--- a/aws/cloudwatch/dynamodb/dynamodb.hcl
+++ b/aws/cloudwatch/dynamodb/dynamodb.hcl
@@ -53,7 +53,7 @@ scraper aws_dynamodb_table_operation_cloudwatch module {
   gauge "latency" {
     source cloudwatch "latency" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "AWS/DynamoDB"
         metric_name = "SuccessfulRequestLatency"
 

--- a/aws/cloudwatch/ec2/ec2.hcl
+++ b/aws/cloudwatch/ec2/ec2.hcl
@@ -8,7 +8,7 @@ scraper aws_ec2_cloudwatch module {
   gauge "cpu" {
     source cloudwatch "cpu" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "AWS/EC2"
         metric_name = "CPUUtilization"
 

--- a/aws/cloudwatch/eks/eks.hcl
+++ b/aws/cloudwatch/eks/eks.hcl
@@ -34,7 +34,7 @@ scraper aws_eks_cluster_cloudwatch module {
   gauge "node_cpu_utilization" {
     source cloudwatch "node_cpu_utilization" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "ContainerInsights"
         metric_name = "node_cpu_utilization"
         dimensions = {
@@ -47,7 +47,7 @@ scraper aws_eks_cluster_cloudwatch module {
   gauge "node_memory_utilization" {
     source cloudwatch "node_memory_utilization" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "ContainerInsights"
         metric_name = "node_memory_utilization"
         dimensions = {
@@ -60,7 +60,7 @@ scraper aws_eks_cluster_cloudwatch module {
   gauge "node_filesystem_utilization" {
     source cloudwatch "node_filesystem_utilization" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "ContainerInsights"
         metric_name = "node_filesystem_utilization"
         dimensions = {
@@ -81,7 +81,7 @@ scraper aws_eks_service_cloudwatch module {
   gauge "pod_cpu_utilization" {
     source cloudwatch "pod_cpu_utilization" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "ContainerInsights"
         metric_name = "pod_cpu_utilization"
         dimensions = {
@@ -96,7 +96,7 @@ scraper aws_eks_service_cloudwatch module {
   gauge "pod_memory_utilization" {
     source cloudwatch "pod_memory_utilization" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "ContainerInsights"
         metric_name = "pod_memory_utilization"
         dimensions = {
@@ -111,7 +111,7 @@ scraper aws_eks_service_cloudwatch module {
   gauge "pod_cpu_utilization_over_pod_limit" {
     source cloudwatch "pod_cpu_utilization_over_pod_limit" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "ContainerInsights"
         metric_name = "pod_cpu_utilization_over_pod_limit"
         dimensions = {
@@ -126,7 +126,7 @@ scraper aws_eks_service_cloudwatch module {
   gauge "pod_memory_utilization_over_pod_limit" {
     source cloudwatch "pod_memory_utilization_over_pod_limit" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "ContainerInsights"
         metric_name = "pod_memory_utilization_over_pod_limit"
         dimensions = {
@@ -141,7 +141,7 @@ scraper aws_eks_service_cloudwatch module {
   gauge "pod_network_rx_bytes" {
     source cloudwatch "pod_network_rx_bytes" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Sum"
         namespace   = "ContainerInsights"
         metric_name = "pod_network_rx_bytes"
         dimensions = {
@@ -156,7 +156,7 @@ scraper aws_eks_service_cloudwatch module {
   gauge "pod_network_tx_bytes" {
     source cloudwatch "pod_network_tx_bytes" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Sum"
         namespace   = "ContainerInsights"
         metric_name = "pod_network_tx_bytes"
         dimensions = {
@@ -194,7 +194,7 @@ scraper aws_eks_pod_cloudwatch module {
   gauge "pod_cpu_utilization" {
     source cloudwatch "pod_cpu_utilization" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "ContainerInsights"
         metric_name = "pod_cpu_utilization"
         dimensions = {
@@ -209,7 +209,7 @@ scraper aws_eks_pod_cloudwatch module {
   gauge "pod_memory_utilization" {
     source cloudwatch "pod_memory_utilization" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "ContainerInsights"
         metric_name = "pod_memory_utilization"
         dimensions = {
@@ -224,7 +224,7 @@ scraper aws_eks_pod_cloudwatch module {
   gauge "pod_cpu_utilization_over_pod_limit" {
     source cloudwatch "pod_cpu_utilization_over_pod_limit" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "ContainerInsights"
         metric_name = "pod_cpu_utilization_over_pod_limit"
         dimensions = {
@@ -239,7 +239,7 @@ scraper aws_eks_pod_cloudwatch module {
   gauge "pod_memory_utilization_over_pod_limit" {
     source cloudwatch "pod_memory_utilization_over_pod_limit" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "ContainerInsights"
         metric_name = "pod_memory_utilization_over_pod_limit"
         dimensions = {
@@ -254,7 +254,7 @@ scraper aws_eks_pod_cloudwatch module {
   gauge "pod_network_rx_bytes" {
     source cloudwatch "pod_network_rx_bytes" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Sum"
         namespace   = "ContainerInsights"
         metric_name = "pod_network_rx_bytes"
         dimensions = {
@@ -269,7 +269,7 @@ scraper aws_eks_pod_cloudwatch module {
   gauge "pod_network_tx_bytes" {
     source cloudwatch "pod_network_rx_bytes" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Sum"
         namespace   = "ContainerInsights"
         metric_name = "pod_network_tx_bytes"
         dimensions = {
@@ -307,7 +307,7 @@ scraper aws_eks_node_cloudwatch module {
   gauge "node_cpu_utilization" {
     source cloudwatch "node_cpu_utilization" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "ContainerInsights"
         metric_name = "node_cpu_utilization"
         dimensions = {
@@ -322,7 +322,7 @@ scraper aws_eks_node_cloudwatch module {
   gauge "node_filesystem_utilization" {
     source cloudwatch "node_filesystem_utilization" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "ContainerInsights"
         metric_name = "node_filesystem_utilization"
         dimensions = {
@@ -337,7 +337,7 @@ scraper aws_eks_node_cloudwatch module {
   gauge "node_memory_utilization" {
     source cloudwatch "node_memory_utilization" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "ContainerInsights"
         metric_name = "node_memory_utilization"
         dimensions = {

--- a/aws/cloudwatch/elasticcache/elasticcache.hcl
+++ b/aws/cloudwatch/elasticcache/elasticcache.hcl
@@ -114,9 +114,9 @@ scraper aws_elasticache_redis_cloudwatch module {
   vector "latency" {
     dimension_label = "stat"
 
-    source cloudwatch "min" {
+    source cloudwatch "count" {
       query {
-        aggregator  = "Minimum"
+        aggregator  = "SampleCount"
         namespace   = "AWS/ElastiCache"
         metric_name = "SetTypeCmdsLatency"
 
@@ -127,22 +127,9 @@ scraper aws_elasticache_redis_cloudwatch module {
       }
     }
 
-    source cloudwatch "max" {
+    source cloudwatch "sum" {
       query {
-        aggregator  = "Maximum"
-        namespace   = "AWS/ElastiCache"
-        metric_name = "SetTypeCmdsLatency"
-
-        dimensions = {
-          CacheClusterId = resources.each.CacheClusterId
-          CacheNodeId    = "0001"
-        }
-      }
-    }
-
-    source cloudwatch "avg" {
-      query {
-        aggregator  = "Average"
+        aggregator  = "Sum"
         namespace   = "AWS/ElastiCache"
         metric_name = "SetTypeCmdsLatency"
 

--- a/aws/cloudwatch/elasticcache/elasticcache.hcl
+++ b/aws/cloudwatch/elasticcache/elasticcache.hcl
@@ -198,7 +198,7 @@ scraper aws_elasticache_cluster_cloudwatch module {
   gauge "cpu_used" {
     source cloudwatch "EngineCPUUtilization" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "AWS/ElastiCache"
         metric_name = "EngineCPUUtilization"
 
@@ -213,7 +213,7 @@ scraper aws_elasticache_cluster_cloudwatch module {
   gauge "memory_used" {
     source cloudwatch "DatabaseMemoryUsagePercentage" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "AWS/ElastiCache"
         metric_name = "DatabaseMemoryUsagePercentage"
 

--- a/aws/cloudwatch/elasticsearch/elasticsearch.hcl
+++ b/aws/cloudwatch/elasticsearch/elasticsearch.hcl
@@ -115,7 +115,7 @@ scraper aws_elasticsearch_cloudwatch module {
   gauge "cpu" {
     source cloudwatch "cpu" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "AWS/ES"
         metric_name = "CPUUtilization"
 
@@ -231,7 +231,7 @@ scraper aws_elasticsearch_master_cloudwatch module {
   gauge "cpu" {
     source cloudwatch "cpu" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "AWS/ES"
         metric_name = "MasterCPUUtilization"
 

--- a/aws/cloudwatch/elb/elb.hcl
+++ b/aws/cloudwatch/elb/elb.hcl
@@ -5,7 +5,6 @@ scraper aws_elb_cloudwatch module {
   resolution = 60
   lag        = 120
 
-
   gauge "throughput" {
     source cloudwatch "throughput" {
       query {
@@ -93,9 +92,9 @@ scraper aws_elb_cloudwatch module {
   vector "latency" {
     dimension_label = "stat"
 
-    source cloudwatch "min" {
+    source cloudwatch "count" {
       query {
-        aggregator  = "Minimum"
+        aggregator  = "SampleCount"
         namespace   = "AWS/ELB"
         metric_name = "Latency"
 
@@ -105,21 +104,9 @@ scraper aws_elb_cloudwatch module {
       }
     }
 
-    source cloudwatch "max" {
+    source cloudwatch "sum" {
       query {
-        aggregator  = "Maximum"
-        namespace   = "AWS/ELB"
-        metric_name = "Latency"
-
-        dimensions = {
-          LoadBalancerName = resources.each.LoadBalancerName
-        }
-      }
-    }
-
-    source cloudwatch "avg" {
-      query {
-        aggregator  = "Average"
+        aggregator  = "Sum"
         namespace   = "AWS/ELB"
         metric_name = "Latency"
 

--- a/aws/cloudwatch/lambda/lambda.hcl
+++ b/aws/cloudwatch/lambda/lambda.hcl
@@ -22,9 +22,9 @@ scraper aws_lambda_cloudwatch module {
   vector "latency" {
     dimension_label = "stat"
 
-    source cloudwatch "min" {
+    source cloudwatch "count" {
       query {
-        aggregator  = "Minimum"
+        aggregator  = "SampleCount"
         namespace   = "AWS/Lambda"
         metric_name = "Duration"
 
@@ -34,21 +34,9 @@ scraper aws_lambda_cloudwatch module {
       }
     }
 
-    source cloudwatch "max" {
+    source cloudwatch "sum" {
       query {
-        aggregator  = "Maximum"
-        namespace   = "AWS/Lambda"
-        metric_name = "Duration"
-
-        dimensions = {
-          FunctionName = resources.each.FunctionName
-        }
-      }
-    }
-
-    source cloudwatch "avg" {
-      query {
-        aggregator  = "Average"
+        aggregator  = "Sum"
         namespace   = "AWS/Lambda"
         metric_name = "Duration"
 

--- a/aws/cloudwatch/msk/msk.hcl
+++ b/aws/cloudwatch/msk/msk.hcl
@@ -41,7 +41,7 @@ scraper aws_msk_topic_per_broker_cloudwatch module {
   gauge "messages_in" {
     source cloudwatch "messages_in" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Sum"
         namespace   = "AWS/Kafka"
         metric_name = "MessagesInPerSec"
 
@@ -57,7 +57,7 @@ scraper aws_msk_topic_per_broker_cloudwatch module {
   gauge "fetch_msg_conversions" {
     source cloudwatch "fetch_msg_conversions" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Sum"
         namespace   = "AWS/Kafka"
         metric_name = "FetchMessageConversionsPerSec"
 
@@ -73,7 +73,7 @@ scraper aws_msk_topic_per_broker_cloudwatch module {
   gauge "produce_msg_conversions" {
     source cloudwatch "produce_msg_conversions" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Sum"
         namespace   = "AWS/Kafka"
         metric_name = "ProduceMessageConversionsPerSec"
 
@@ -218,7 +218,7 @@ scraper aws_msk_broker_cloudwatch module {
   gauge "messages_in" {
     source cloudwatch "messages_in" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Sum"
         namespace   = "AWS/Kafka"
         metric_name = "MessagesInPerSec"
 
@@ -248,7 +248,7 @@ scraper aws_msk_broker_cloudwatch module {
   gauge "produce_time_ms_mean" {
     source cloudwatch "produce_time_ms_mean" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Sum"
         namespace   = "AWS/Kafka"
         metric_name = "ProduceTotalTimeMsMean"
 
@@ -278,7 +278,7 @@ scraper aws_msk_broker_cloudwatch module {
   gauge "request_time" {
     source cloudwatch "request_time" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "AWS/Kafka"
         metric_name = "RequestTime"
 
@@ -293,7 +293,7 @@ scraper aws_msk_broker_cloudwatch module {
   gauge "produce_msg_conversions" {
     source cloudwatch "produce_msg_conversions" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Sum"
         namespace   = "AWS/Kafka"
         metric_name = "ProduceMessageConversionsPerSec"
 
@@ -308,7 +308,7 @@ scraper aws_msk_broker_cloudwatch module {
   gauge "fetch_msg_conversions" {
     source cloudwatch "fetch_msg_conversions" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Sum"
         namespace   = "AWS/Kafka"
         metric_name = "FetchMessageConversionsPerSec"
 
@@ -323,7 +323,7 @@ scraper aws_msk_broker_cloudwatch module {
   gauge "fetch_time_ms_mean" {
     source cloudwatch "fetch_time_ms_mean" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "AWS/Kafka"
         metric_name = "FetchConsumerTotalTimeMsMean"
 

--- a/aws/cloudwatch/rds/rds.hcl
+++ b/aws/cloudwatch/rds/rds.hcl
@@ -22,7 +22,7 @@ scraper aws_rds_cloudwatch module {
   gauge "write_iops" {
     source cloudwatch "write_iops" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "AWS/RDS"
         metric_name = "WriteIOPS"
 
@@ -36,7 +36,7 @@ scraper aws_rds_cloudwatch module {
   gauge "read_iops" {
     source cloudwatch "read_iops" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "AWS/RDS"
         metric_name = "ReadIOPS"
 
@@ -50,7 +50,7 @@ scraper aws_rds_cloudwatch module {
   gauge "read_latency" {
     source cloudwatch "read_latency" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "AWS/RDS"
         metric_name = "ReadLatency"
 
@@ -64,7 +64,7 @@ scraper aws_rds_cloudwatch module {
   gauge "write_latency" {
     source cloudwatch "wrtie_latency" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "AWS/RDS"
         metric_name = "WriteLatency"
 
@@ -78,7 +78,7 @@ scraper aws_rds_cloudwatch module {
   gauge "network_in" {
     source cloudwatch "network_in" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Sum"
         namespace   = "AWS/RDS"
         metric_name = "NetworkReceiveThroughput"
 
@@ -92,7 +92,7 @@ scraper aws_rds_cloudwatch module {
   gauge "network_out" {
     source cloudwatch "network_out" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Sum"
         namespace   = "AWS/RDS"
         metric_name = "NetworkTransmitThroughput"
 
@@ -106,7 +106,7 @@ scraper aws_rds_cloudwatch module {
   gauge "cpu" {
     source cloudwatch "cpu" {
       query {
-        aggregator  = "Average"
+        aggregator  = "Maximum"
         namespace   = "AWS/RDS"
         metric_name = "CPUUtilization"
 


### PR DESCRIPTION
**Request Latencies**
- Use `sum` and `count` for request based latencies

**Remove `average` from across modules**
- When we roll-up time series data by averaging it, it cannot be
    further averaged
- So, replace all Average stats with other appropriate stats
     - Use `Sum` for any throughput like metric
     - Use `Max` for any duration based metric